### PR TITLE
Fix typos, grammar, and improve readme formatting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,13 +3,16 @@
 [![npm version](https://badge.fury.io/js/eswrap.svg)](https://badge.fury.io/js/eswrap)
 [![Build Status](https://travis-ci.org/kevinastone/eswrap.svg?branch=master)](https://travis-ci.org/kevinastone/eswrap)
 
-eswrap is a ecmascript formatting utlity.  It will parse a supplied block of code and apply formatting to attempt to fit it within a col width.
+**eswrap** is an ECMAScript formatting utility.
+It attempts to reformat a code block to fit within a specified column count:
 
-```
+```bash
 echo "[variable1, variable2, variable3];" | eswrap --limit 20
-[
+
+# Output:
+'[
   variable1,
   variable2,
   variable3,
-];
+];'
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -10,9 +10,9 @@ It attempts to reformat a code block to fit within a specified column count:
 echo "[variable1, variable2, variable3];" | eswrap --limit 20
 
 # Output:
-'[
+[
   variable1,
   variable2,
   variable3,
-];'
+];
 ```

--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ const DEFAULT_LINE_LENGTH = 80;
 
 program
   .version(version)
-  .description('format ecmascript code')
+  .description('format ECMAScript code')
   .option(
     '-l, --limit <cols>',
     `line limit (defaults to ${DEFAULT_LINE_LENGTH})`,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eswrap",
   "version": "0.0.2",
-  "description": "Wrap ecmascript code to retain formating",
+  "description": "Wrap ECMAScript source to fit within a column count.",
   "main": "index.js",
   "bin": {
     "eswrap": "bin/eswrap.js"

--- a/tests/classes.spec.js
+++ b/tests/classes.spec.js
@@ -7,28 +7,28 @@ import transform from './../index';
 describe('Classes', () => {
   describe('Conformance', () => {
     describe('Declaration', () => {
-      it(`it should format simple class declarations`, () => {
+      it(`should format a basic class`, () => {
         expect(transform(dedent`
           class Something {}
         `, 80)).toEqual(dedent`
           class Something {}
         `);
       });
-      it(`it should format simple class declaration with super-classes`, () => {
+      it(`should format a basic subclass`, () => {
         expect(transform(dedent`
           class Something extends Another {}
         `, 80)).toEqual(dedent`
           class Something extends Another {}
         `);
       });
-      it(`it should format simple class expressions`, () => {
+      it(`should format a class expression`, () => {
         expect(transform(dedent`
           const Klass = class {};
         `, 80)).toEqual(dedent`
           const Klass = class {};
         `);
       });
-      it(`it should format named class expressions`, () => {
+      it(`should format a named class expression`, () => {
         expect(transform(dedent`
           const Klass = class Klass {};
         `, 80)).toEqual(dedent`
@@ -37,7 +37,7 @@ describe('Classes', () => {
       });
     });
     describe('Class Methods', () => {
-      it(`it should format simple class constructor`, () => {
+      it(`should format a basic constructor`, () => {
         expect(transform(dedent`
           class Something {
             constructor() {}
@@ -48,7 +48,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format class constructor with arguments`, () => {
+      it(`should format a constructor with an argument list`, () => {
         expect(transform(dedent`
           class Something {
             constructor(something, another) {}
@@ -59,7 +59,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format class constructor with super`, () => {
+      it(`should format a constructor that uses the \`super\` keyword`, () => {
         expect(transform(dedent`
           class Something {
             constructor() {
@@ -74,7 +74,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format simple class method`, () => {
+      it(`should format a basic method`, () => {
         expect(transform(dedent`
           class Something {
             method(something, another) {}
@@ -85,7 +85,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format symbolic class method`, () => {
+      it(`should format a Symbol-keyed generator method`, () => {
         expect(transform(dedent`
           class Something {
             * [Symbol.iterator](something, another) {}
@@ -96,7 +96,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format simple class property getter`, () => {
+      it(`should format a property getter`, () => {
         expect(transform(dedent`
           class Something {
             get property() {}
@@ -107,7 +107,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format simple class property setter`, () => {
+      it(`should format a property setter`, () => {
         expect(transform(dedent`
           class Something {
             set property(value) {}
@@ -120,7 +120,7 @@ describe('Classes', () => {
       });
     });
     describe('Class Properties', () => {
-      it(`it should format simple properties without values`, () => {
+      it(`should format a property declaration without a default value`, () => {
         expect(transform(dedent`
           class Something {
             color;
@@ -131,7 +131,7 @@ describe('Classes', () => {
           }
         `);
       });
-      it(`it should format simple properties with values`, () => {
+      it(`should format a property declaration that defines a default value`, () => {
         expect(transform(dedent`
           class Something {
             color = 'red';

--- a/tests/expressions.spec.js
+++ b/tests/expressions.spec.js
@@ -16,49 +16,49 @@ describe('Expressions', () => {
       });
     });
     describe('Unary Operators', () => {
-      it(`should handle delete unary expressions`, () => {
+      it(`should handle \`delete\``, () => {
         expect(transform(dedent`
           delete a.b;
         `, 80)).toEqual(dedent`
           delete a.b;
         `);
       });
-      it(`should handle typeof unary expressions`, () => {
+      it(`should handle \`typeof\``, () => {
         expect(transform(dedent`
           typeof a.b;
         `, 80)).toEqual(dedent`
           typeof a.b;
         `);
       });
-      it(`should handle void unary expressions`, () => {
+      it(`should handle \`void\``, () => {
         expect(transform(dedent`
           void a.b;
         `, 80)).toEqual(dedent`
           void a.b;
         `);
       });
-      it(`should handle prefix unary expressions`, () => {
+      it(`should handle prefix operators`, () => {
         expect(transform(dedent`
           var a = !true;
         `, 80)).toEqual(dedent`
           var a = !true;
         `);
       });
-      it(`should handle prefix negation expressions`, () => {
+      it(`should handle negated prefix operators`, () => {
         expect(transform(dedent`
           var a = -x;
         `, 80)).toEqual(dedent`
           var a = -x;
         `);
       });
-      it(`should handle prefis update expressions`, () => {
+      it(`should handle prefix increments`, () => {
         expect(transform(dedent`
           var a = ++count;
         `, 80)).toEqual(dedent`
           var a = ++count;
         `);
       });
-      it(`should handle suffix update expressions`, () => {
+      it(`should handle postfix increments`, () => {
         expect(transform(dedent`
           var a = count++;
         `, 80)).toEqual(dedent`
@@ -129,15 +129,15 @@ describe('Expressions', () => {
       `);
     });
   });
-  describe('Ternary', () => {
-    it(`should not split ternary under length`, () => {
+  describe('Ternary operators', () => {
+    it(`should not split ternary operators under length`, () => {
       expect(transform(dedent`
         var a = b ? c : d;
       `, 20)).toEqual(dedent`
         var a = b ? c : d;
       `);
     });
-    it(`should split ternary over length`, () => {
+    it(`should split ternary operators over length`, () => {
       expect(transform(dedent`
         var result = condition ? truthy : falsy;
       `, 30)).toEqual(dedent`
@@ -146,7 +146,7 @@ describe('Expressions', () => {
           : falsy;
       `);
     });
-    it(`should split nested ternary over length`, () => {
+    it(`should split nested ternary operators over length`, () => {
       expect(transform(dedent`
         var result = condition ? another ? wanted : secondary : lastly;
       `, 30)).toEqual(dedent`

--- a/tests/functions.spec.js
+++ b/tests/functions.spec.js
@@ -7,21 +7,21 @@ import transform from './../index';
 describe('Functions', () => {
   describe('Conformance', () => {
     describe('Declarations', () => {
-      it(`it should handle default arguments`, () => {
+      it(`should handle default arguments`, () => {
         expect(transform(dedent`
           function f(a = 1, b = 2) {}
         `, 80)).toEqual(dedent`
           function f(a = 1, b = 2) {}
         `);
       });
-      it(`it should handle rest arguments`, () => {
+      it(`should handle rest arguments`, () => {
         expect(transform(dedent`
           function f(...a) {}
         `, 80)).toEqual(dedent`
           function f(...a) {}
         `);
       });
-      it(`it should handle spread arguments`, () => {
+      it(`should handle spread arguments`, () => {
         expect(transform(dedent`
           f(...a);
         `, 80)).toEqual(dedent`
@@ -30,21 +30,21 @@ describe('Functions', () => {
       });
     });
     describe('Expressions', () => {
-      it(`it should handle expresions`, () => {
+      it(`should handle expressions`, () => {
         expect(transform(dedent`
           func(function(a, b) {});
         `, 80)).toEqual(dedent`
           func(function(a, b) {});
         `);
       });
-      it(`it should handle expresions with other parameters`, () => {
+      it(`should handle expressions with other parameters`, () => {
         expect(transform(dedent`
           func(function(a, b) {}, another);
         `, 80)).toEqual(dedent`
           func(function(a, b) {}, another);
         `);
       });
-      it(`it should handle expresions with bodies`, () => {
+      it(`should handle expressions with bodies`, () => {
         expect(transform(dedent`
           func(function(a, b) {
             return false;

--- a/tests/iterables.spec.js
+++ b/tests/iterables.spec.js
@@ -4,13 +4,13 @@ import 'chai';
 import { product } from './../lib/iterables';
 
 describe('product', () => {
-  it(`iterate empty inputs`, () => {
+  it(`iterates empty inputs`, () => {
     expect(Array.from(product())).toEqual([]);
   });
-  it(`iterate single values`, () => {
+  it(`iterates single values`, () => {
     expect(Array.from(product([1, 2, 3]))).toEqual([[1], [2], [3]]);
   });
-  it(`iterate multiple values`, () => {
+  it(`iterates multiple values`, () => {
     expect(Array.from(product([1, 2], ['A', 'B']))).toEqual([[1, 'A'], [1, 'B'], [2, 'A'], [2, 'B']]);
   });
 });

--- a/tests/literals.spec.js
+++ b/tests/literals.spec.js
@@ -4,22 +4,22 @@ import 'chai';
 import transform from './../index';
 
 describe('Literals', () => {
-  describe('NumericLiterals', () => {
+  describe('Numbers', () => {
     it(`shouldn't wrap literals`, () => {
       expect(transform(`var a = 20;`, 20)).toEqual(`var a = 20;`);
     });
   });
-  describe('BooleanLiterals', () => {
+  describe('Boolean values', () => {
     it(`shouldn't wrap literals`, () => {
       expect(transform(`var a = true;`, 20)).toEqual(`var a = true;`);
     });
   });
-  describe('StringLiterals', () => {
+  describe('Strings', () => {
     it(`shouldn't wrap literals`, () => {
       expect(transform(`var a = 'hi';`, 20)).toEqual(`var a = 'hi';`);
     });
   });
-  describe('RegexLiterals', () => {
+  describe('RegExp literals', () => {
     it(`shouldn't wrap literals`, () => {
       expect(transform(`var a = /hi/;`, 20)).toEqual(`var a = /hi/;`);
     });
@@ -27,7 +27,7 @@ describe('Literals', () => {
       expect(transform(`var a = /hi/gi;`, 20)).toEqual(`var a = /hi/gi;`);
     });
   });
-  describe('TemplateLiterals', () => {
+  describe('Template literals', () => {
     it(`shouldn't wrap literals`, () => {
       expect(transform('var a = `hi`;', 20)).toEqual('var a = `hi`;');
     });

--- a/tests/objects.spec.js
+++ b/tests/objects.spec.js
@@ -6,15 +6,15 @@ import transform from './../index';
 
 describe('Objects', () => {
   describe('Conformance', () => {
-    describe('Object Pattern', () => {
-      it(`it should format shorthand object pattern`, () => {
+    describe('Destructured Assignment', () => {
+      it(`should format shorthand destructuring`, () => {
         expect(transform(dedent`
           var { a, b } = { a: something, b: another };
         `, 80)).toEqual(dedent`
           var { a, b } = { a: something, b: another };
         `);
       });
-      it(`it should format longhand object pattern`, () => {
+      it(`should format longhand destructuring`, () => {
         expect(transform(dedent`
           var { a: first, b: second } = { a: something, b: another };
         `, 80)).toEqual(dedent`
@@ -23,7 +23,7 @@ describe('Objects', () => {
       });
     });
     xdescribe('Object Methods', () => {
-      it(`it should format simple object method`, () => {
+      it(`should format simple methods`, () => {
         expect(transform(dedent`
           var myObj = {
             method(something, another) {}
@@ -34,7 +34,7 @@ describe('Objects', () => {
           }
         `);
       });
-      it(`it should format simple object property getter`, () => {
+      it(`should format property getters`, () => {
         expect(transform(dedent`
           var myObj = {
             get property() {}
@@ -45,7 +45,7 @@ describe('Objects', () => {
           }
         `);
       });
-      it(`it should format simple object property setter`, () => {
+      it(`should format property setters`, () => {
         expect(transform(dedent`
           var myObj = {
             set property(value) {}

--- a/tests/statements.spec.js
+++ b/tests/statements.spec.js
@@ -6,14 +6,14 @@ import transform from './../index';
 
 describe('Statements', () => {
   describe('Conformance', () => {
-    it(`should handle throw statements`, () => {
+    it(`should handle \`throw\``, () => {
       expect(transform(dedent`
         throw error;
       `, 80)).toEqual(dedent`
         throw error;
       `);
     });
-    it(`should handle break statements`, () => {
+    it(`should handle \`break\``, () => {
       expect(transform(dedent`
         while (true) {
           break;
@@ -24,7 +24,7 @@ describe('Statements', () => {
         }
       `);
     });
-    it(`should handle try-catch statements`, () => {
+    it(`should handle \`try/catch\``, () => {
       expect(transform(dedent`
         try {}
         catch (ex) {}
@@ -33,7 +33,7 @@ describe('Statements', () => {
         catch (ex) {}
       `);
     });
-    it(`should handle try-finally statements`, () => {
+    it(`should handle \`try/finally\``, () => {
       expect(transform(dedent`
         try {}
         finally {}
@@ -44,12 +44,12 @@ describe('Statements', () => {
     });
   });
   describe('If Statements', () => {
-    it(`shouldn't wrap if statements if under length`, () => {
+    it(`shouldn't wrap \`if\` when under length`, () => {
       expect(transform(`if (a == true) {}`, 20)).toEqual(dedent`
         if (a == true) {}
       `);
     });
-    it(`shouldn't wrap if-else statements if under length`, () => {
+    it(`shouldn't wrap \`if/else\` when under length`, () => {
       expect(transform(dedent`
         if (a == true) {
           true;
@@ -64,7 +64,7 @@ describe('Statements', () => {
         }
       `);
     });
-    it(`shouldn't wrap if-elseif statements if under length`, () => {
+    it(`shouldn't wrap \`if/elseif\` when under length`, () => {
       expect(transform(dedent`
         if (a == true) {
           true;
@@ -79,7 +79,7 @@ describe('Statements', () => {
         } else {}
       `);
     });
-    it(`should wrap if statements at the binary expressions`, () => {
+    it(`should wrap \`if\` at binary expressions`, () => {
       expect(transform(`if (something || another || more) {}`, 20)).toEqual(dedent`
         if (
           something ||
@@ -90,12 +90,12 @@ describe('Statements', () => {
     });
   });
   describe('While Statements', () => {
-    it(`shouldn't wrap while statements while under length`, () => {
+    it(`shouldn't wrap \`while\` if under length`, () => {
       expect(transform(`while (a == true) {}`, 20)).toEqual(dedent`
         while (a == true) {}
       `);
     });
-    it(`should wrap while statements at the binary expressions`, () => {
+    it(`should wrap \`while\` at binary expressions`, () => {
       expect(transform(`while (something || another || more) {}`, 20)).toEqual(dedent`
         while (
           something ||
@@ -105,13 +105,13 @@ describe('Statements', () => {
       `);
     });
   });
-  describe('For of Statements', () => {
-    it(`shouldn't wrap for-of statements if under length`, () => {
+  describe('For-of Statements', () => {
+    it(`shouldn't wrap \`for-of\` if under length`, () => {
       expect(transform(`for (const a of []) {}`, 30)).toEqual(dedent`
         for (const a of []) {}
       `);
     });
-    it(`should wrap if statements at the binary expressions`, () => {
+    it(`should wrap \`for-of\` at binary expressions`, () => {
       expect(transform(`for (const c of iter) {}`, 20)).toEqual(dedent`
         for (
           const c of iter
@@ -120,27 +120,18 @@ describe('Statements', () => {
     });
   });
   describe('For Statements', () => {
-    it(`shouldn't wrap for statements if under length`, () => {
+    it(`shouldn't wrap \`for\` if under length`, () => {
       expect(transform(dedent`
         for (let i = 0; i < 10; i++) {}
       `, 40)).toEqual(dedent`
         for (let i = 0; i < 10; i++) {}
       `);
     });
-    it(`shouldn't wrap empty for statements if under length`, () => {
+    it(`shouldn't wrap empty \`for\` loops if under length`, () => {
       expect(transform(dedent`
         for (;;) {}
       `, 40)).toEqual(dedent`
         for (;;) {}
-      `);
-    });
-  });
-  describe('For Statements', () => {
-    it(`shouldn't wrap for statements if under length`, () => {
-      expect(transform(dedent`
-        for (let i = 0; i < 10; i++) {}
-      `, 40)).toEqual(dedent`
-        for (let i = 0; i < 10; i++) {}
       `);
     });
   });


### PR DESCRIPTION
This PR does exactly as advertised. =) And by "PR", I mean `pedantic revisions`.

ECMAScript is officially typeset with five leading majuscules, which was the first thing I fixed. Then I kinda got carried away polishing other typos and improving overall grammar.

~~As I joke, I also reformatted your code to use tabs instead of spaces~~... almost did, hahaha.
